### PR TITLE
Add comprehensive unit tests for session and playlist features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,7 +305,6 @@ app.*.map.json
 # VSCode
 .vscode/
 /--no-codesign/
-/test/
 /ios/Podfile.lock
 /macos/Podfile.lock
 /devtools_options.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dev_dependencies:
   custom_lint: ^0.8.1
   hive_ce_generator: ^1.9.5
   flutter_launcher_icons: ^0.14.1
+  mocktail: ^1.0.0
 
 flutter_launcher_icons:
   windows:

--- a/test/features/session/data/session_parameter_test.dart
+++ b/test/features/session/data/session_parameter_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:eq_trainer/features/session/data/session_parameter.dart';
+
+void main() {
+  group('SessionParameter', () {
+    late SessionParameter param;
+
+    setUp(() {
+      param = SessionParameter();
+    });
+
+    test('default values are correct', () {
+      expect(param.startingBand, equals(3));
+      expect(param.gain, equals(6));
+      expect(param.qFactor, equals(1.0));
+      expect(param.filterType, equals(FilterType.peakDip));
+      expect(param.threshold, equals(3));
+    });
+
+    group('startingBand clamping', () {
+      test('clamps to minimum of 2 when set below range', () {
+        param.startingBand = 0;
+        expect(param.startingBand, equals(2));
+      });
+
+      test('clamps to minimum of 2 when set to 1', () {
+        param.startingBand = 1;
+        expect(param.startingBand, equals(2));
+      });
+
+      test('clamps to maximum of 25 when set above range', () {
+        param.startingBand = 30;
+        expect(param.startingBand, equals(25));
+      });
+
+      test('clamps to maximum of 25 when set to 26', () {
+        param.startingBand = 26;
+        expect(param.startingBand, equals(25));
+      });
+
+      test('accepts minimum boundary value of 2', () {
+        param.startingBand = 2;
+        expect(param.startingBand, equals(2));
+      });
+
+      test('accepts maximum boundary value of 25', () {
+        param.startingBand = 25;
+        expect(param.startingBand, equals(25));
+      });
+
+      test('accepts a mid-range value', () {
+        param.startingBand = 10;
+        expect(param.startingBand, equals(10));
+      });
+
+      test('clamps negative values to 2', () {
+        param.startingBand = -5;
+        expect(param.startingBand, equals(2));
+      });
+    });
+
+    group('gain setter', () {
+      test('stores the assigned value', () {
+        param.gain = 12;
+        expect(param.gain, equals(12));
+      });
+
+      test('stores negative gain values', () {
+        param.gain = -6;
+        expect(param.gain, equals(-6));
+      });
+    });
+
+    group('qFactor setter', () {
+      test('stores the assigned value', () {
+        param.qFactor = 2.5;
+        expect(param.qFactor, closeTo(2.5, 1e-9));
+      });
+    });
+
+    group('filterType setter', () {
+      test('can be set to FilterType.peak', () {
+        param.filterType = FilterType.peak;
+        expect(param.filterType, equals(FilterType.peak));
+      });
+
+      test('can be set to FilterType.dip', () {
+        param.filterType = FilterType.dip;
+        expect(param.filterType, equals(FilterType.dip));
+      });
+
+      test('can be set to FilterType.peakDip', () {
+        param.filterType = FilterType.peakDip;
+        expect(param.filterType, equals(FilterType.peakDip));
+      });
+    });
+
+    group('threshold setter', () {
+      test('stores the assigned value', () {
+        param.threshold = 5;
+        expect(param.threshold, equals(5));
+      });
+    });
+  });
+}

--- a/test/features/session/model/frequency_calculator_test.dart
+++ b/test/features/session/model/frequency_calculator_test.dart
@@ -1,0 +1,146 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:eq_trainer/features/session/model/frequency_calculator.dart';
+import 'package:eq_trainer/features/session/data/session_parameter.dart';
+
+void main() {
+  group('FrequencyCalculator.compute', () {
+    late SessionParameter param;
+
+    setUp(() {
+      param = SessionParameter();
+    });
+
+    test('centerFreqLogList has exactly startingBand entries', () {
+      param.startingBand = 5;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.centerFreqLogList.length, equals(5));
+    });
+
+    test('centerFreqLinearList has exactly startingBand entries', () {
+      param.startingBand = 4;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.centerFreqLinearList.length, equals(4));
+    });
+
+    test('log frequencies stay within [20, 20000] Hz range', () {
+      param.startingBand = 10;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      for (final freq in result.centerFreqLogList) {
+        expect(freq, greaterThanOrEqualTo(20.0));
+        expect(freq, lessThanOrEqualTo(20000.0));
+      }
+    });
+
+    test('log frequencies follow geometric progression', () {
+      param.startingBand = 6;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      final freqs = result.centerFreqLogList;
+      // Each step should multiply by the same ratio
+      if (freqs.length >= 3) {
+        final ratio1 = freqs[1] / freqs[0];
+        final ratio2 = freqs[2] / freqs[1];
+        expect(ratio1, closeTo(ratio2, 1e-6));
+      }
+    });
+
+    test('linear frequencies are evenly spaced', () {
+      param.startingBand = 5;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      final linears = result.centerFreqLinearList;
+      if (linears.length >= 2) {
+        final gap = linears[1] - linears[0];
+        for (int i = 1; i < linears.length - 1; i++) {
+          expect(linears[i + 1] - linears[i], closeTo(gap, 1e-9));
+        }
+      }
+    });
+
+    test('FilterType.peak produces graphBarDataList.length == startingBand', () {
+      param.startingBand = 4;
+      param.filterType = FilterType.peak;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.graphBarDataList.length, equals(4));
+    });
+
+    test('FilterType.dip produces graphBarDataList.length == startingBand', () {
+      param.startingBand = 4;
+      param.filterType = FilterType.dip;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.graphBarDataList.length, equals(4));
+    });
+
+    test('FilterType.peakDip produces graphBarDataList.length == 2 * startingBand', () {
+      param.startingBand = 4;
+      param.filterType = FilterType.peakDip;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.graphBarDataList.length, equals(8));
+    });
+
+    test('first bar in graphBarDataList has color == Colors.blueAccent', () {
+      param.startingBand = 3;
+      param.filterType = FilterType.peak;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.graphBarDataList.isNotEmpty, isTrue);
+      expect(result.graphBarDataList[0].color, equals(Colors.blueAccent));
+    });
+
+    test('remaining bars have color == Colors.redAccent', () {
+      param.startingBand = 3;
+      param.filterType = FilterType.peak;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      for (int i = 1; i < result.graphBarDataList.length; i++) {
+        expect(result.graphBarDataList[i].color, equals(Colors.redAccent));
+      }
+    });
+
+    test('each graph spot list has 61 points (j = 0..60)', () {
+      param.startingBand = 2;
+      param.filterType = FilterType.peak;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      for (final bar in result.graphBarDataList) {
+        expect(bar.spots.length, equals(61));
+      }
+    });
+
+    test('peak spots have positive y values', () {
+      param.startingBand = 2;
+      param.filterType = FilterType.peak;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      // All peak spot y values should be >= 0
+      for (final bar in result.graphBarDataList) {
+        for (final spot in bar.spots) {
+          expect(spot.y, greaterThanOrEqualTo(0.0));
+        }
+      }
+    });
+
+    test('dip spots have non-positive y values', () {
+      param.startingBand = 2;
+      param.filterType = FilterType.dip;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      // All dip spot y values should be <= 0
+      for (final bar in result.graphBarDataList) {
+        for (final spot in bar.spots) {
+          expect(spot.y, lessThanOrEqualTo(0.0));
+        }
+      }
+    });
+
+    test('works for minimum startingBand of 2', () {
+      param.startingBand = 2;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.centerFreqLogList.length, equals(2));
+      expect(result.centerFreqLinearList.length, equals(2));
+    });
+
+    test('works for maximum startingBand of 25', () {
+      param.startingBand = 25;
+      final result = FrequencyCalculator.compute(sessionParameter: param);
+      expect(result.centerFreqLogList.length, equals(25));
+      expect(result.centerFreqLinearList.length, equals(25));
+    });
+  });
+}

--- a/test/features/session/model/session_store_test.dart
+++ b/test/features/session/model/session_store_test.dart
@@ -1,0 +1,321 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:eq_trainer/features/session/model/session_store.dart';
+
+void main() {
+  group('SessionStore', () {
+    late SessionStore store;
+
+    setUp(() {
+      store = SessionStore();
+    });
+
+    // -------------------------------------------------------------------------
+    // resultPercentage
+    // -------------------------------------------------------------------------
+    group('resultPercentage', () {
+      test('returns 0.0 when no sessions have been played', () {
+        expect(store.resultPercentage, equals(0.0));
+      });
+
+      test('returns 100.0 when all answers are correct', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        expect(store.resultPercentage, equals(100.0));
+      });
+
+      test('returns 0.0 when all answers are incorrect', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.resultPercentage, equals(0.0));
+      });
+
+      test('returns 50.0 for half correct', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.resultPercentage, equals(50.0));
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getResultPercentagePerFreq
+    // -------------------------------------------------------------------------
+    group('getResultPercentagePerFreq', () {
+      test('returns "-" for negative index', () {
+        expect(store.getResultPercentagePerFreq(-1), equals('-'));
+      });
+
+      test('returns "-" for index >= 7', () {
+        expect(store.getResultPercentagePerFreq(7), equals('-'));
+      });
+
+      test('returns "-" when no attempts for that band', () {
+        expect(store.getResultPercentagePerFreq(0), equals('-'));
+      });
+
+      test('returns "100.00%" when all attempts for a band are correct', () {
+        // 440 Hz falls in band 3 (Centre-Midrange: 200–800 Hz? No, 800–1500)
+        // 440 Hz: 200 <= 440 < 800 → band 2 (Lower-Midrange)
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        expect(store.getResultPercentagePerFreq(2), equals('100.00%'));
+      });
+
+      test('returns "0.00%" when all attempts for a band are incorrect', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.getResultPercentagePerFreq(2), equals('0.00%'));
+      });
+
+      test('returns "50.00%" for half correct in a band', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.getResultPercentagePerFreq(2), equals('50.00%'));
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // applySubmission — counters
+    // -------------------------------------------------------------------------
+    group('applySubmission', () {
+      test('correct answer increments resultCorrect', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        expect(store.resultCorrect, equals(1));
+      });
+
+      test('correct answer increments elapsedSession', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        expect(store.elapsedSession, equals(1));
+      });
+
+      test('correct answer increments currentSessionPoint', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        expect(store.currentSessionPoint, equals(1));
+      });
+
+      test('incorrect answer increments resultIncorrect', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.resultIncorrect, equals(1));
+      });
+
+      test('incorrect answer increments elapsedSession', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.elapsedSession, equals(1));
+      });
+
+      test('incorrect answer decrements currentSessionPoint', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        expect(store.currentSessionPoint, equals(-1));
+      });
+
+      test('multiple mixed answers accumulate correctly', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        expect(store.elapsedSession, equals(3));
+        expect(store.resultCorrect, equals(2));
+        expect(store.resultIncorrect, equals(1));
+        expect(store.currentSessionPoint, equals(1)); // +1 -1 +1
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // applySubmission — frequency band routing
+    // -------------------------------------------------------------------------
+    group('applySubmission — frequency band index', () {
+      // Band boundaries:
+      // 0: Sub-Bass       20 <= f < 80
+      // 1: Mid-Bass       80 <= f < 200
+      // 2: Lower-Midrange 200 <= f < 800
+      // 3: Centre-Midrange 800 <= f < 1500
+      // 4: Upper-Midrange 1500 <= f < 5000
+      // 5: Treble         5000 <= f < 10000
+      // 6: Upper-Treble   f >= 10000
+
+      void applyAndCheckBand(double freq, int expectedBand) {
+        final freshStore = SessionStore();
+        freshStore.applySubmission(centerFreq: freq, isCorrect: true);
+        expect(freshStore.elapsedSessionPerFreq[expectedBand], equals(1),
+            reason: '$freq Hz should map to band $expectedBand');
+      }
+
+      test('20 Hz → band 0 (Sub-Bass)', () => applyAndCheckBand(20.0, 0));
+      test('50 Hz → band 0 (Sub-Bass)', () => applyAndCheckBand(50.0, 0));
+      test('79 Hz → band 0 (Sub-Bass boundary)', () => applyAndCheckBand(79.0, 0));
+      test('80 Hz → band 1 (Mid-Bass boundary)', () => applyAndCheckBand(80.0, 1));
+      test('100 Hz → band 1 (Mid-Bass)', () => applyAndCheckBand(100.0, 1));
+      test('199 Hz → band 1 (Mid-Bass boundary)', () => applyAndCheckBand(199.0, 1));
+      test('200 Hz → band 2 (Lower-Midrange boundary)', () => applyAndCheckBand(200.0, 2));
+      test('440 Hz → band 2 (Lower-Midrange)', () => applyAndCheckBand(440.0, 2));
+      test('799 Hz → band 2 (Lower-Midrange boundary)', () => applyAndCheckBand(799.0, 2));
+      test('800 Hz → band 3 (Centre-Midrange boundary)', () => applyAndCheckBand(800.0, 3));
+      test('1000 Hz → band 3 (Centre-Midrange)', () => applyAndCheckBand(1000.0, 3));
+      test('1499 Hz → band 3 (Centre-Midrange boundary)', () => applyAndCheckBand(1499.0, 3));
+      test('1500 Hz → band 4 (Upper-Midrange boundary)', () => applyAndCheckBand(1500.0, 4));
+      test('3000 Hz → band 4 (Upper-Midrange)', () => applyAndCheckBand(3000.0, 4));
+      test('4999 Hz → band 4 (Upper-Midrange boundary)', () => applyAndCheckBand(4999.0, 4));
+      test('5000 Hz → band 5 (Treble boundary)', () => applyAndCheckBand(5000.0, 5));
+      test('8000 Hz → band 5 (Treble)', () => applyAndCheckBand(8000.0, 5));
+      test('9999 Hz → band 5 (Treble boundary)', () => applyAndCheckBand(9999.0, 5));
+      test('10000 Hz → band 6 (Upper-Treble boundary)', () => applyAndCheckBand(10000.0, 6));
+      test('16000 Hz → band 6 (Upper-Treble)', () => applyAndCheckBand(16000.0, 6));
+      test('19999 Hz → band 6 (Upper-Treble)', () => applyAndCheckBand(19999.0, 6));
+    });
+
+    // -------------------------------------------------------------------------
+    // resetResult
+    // -------------------------------------------------------------------------
+    group('resetResult', () {
+      test('resets all counters to zero', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.applySubmission(centerFreq: 440.0, isCorrect: false);
+        store.resetResult();
+
+        expect(store.elapsedSession, equals(0));
+        expect(store.resultCorrect, equals(0));
+        expect(store.resultIncorrect, equals(0));
+        expect(store.currentSessionPoint, equals(0));
+      });
+
+      test('resets per-band counters to zero', () {
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.resetResult();
+
+        for (final count in store.elapsedSessionPerFreq) {
+          expect(count, equals(0));
+        }
+        for (final count in store.correctAnswerPerFreq) {
+          expect(count, equals(0));
+        }
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Session point helpers
+    // -------------------------------------------------------------------------
+    group('session point helpers', () {
+      test('incrementSessionPoint adds 1', () {
+        store.incrementSessionPoint();
+        expect(store.currentSessionPoint, equals(1));
+      });
+
+      test('decrementSessionPoint subtracts 1', () {
+        store.decrementSessionPoint();
+        expect(store.currentSessionPoint, equals(-1));
+      });
+
+      test('resetSessionPoint sets to 0', () {
+        store.incrementSessionPoint();
+        store.incrementSessionPoint();
+        store.resetSessionPoint();
+        expect(store.currentSessionPoint, equals(0));
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Playlist management
+    // -------------------------------------------------------------------------
+    group('setPlaylistPaths', () {
+      test('stores the provided paths', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac']);
+        expect(store.playlistPaths, equals(['/a.flac', '/b.flac']));
+      });
+
+      test('resets currentPlayingAudioIndex to 0', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac', '/c.flac']);
+        store.nextTrack(); // index → 1
+        store.setPlaylistPaths(['/x.flac']);
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+    });
+
+    group('clearPlaylist', () {
+      test('empties playlistPaths', () {
+        store.setPlaylistPaths(['/a.flac']);
+        store.clearPlaylist();
+        expect(store.playlistPaths, isEmpty);
+      });
+
+      test('currentClipPath is null after clear', () {
+        store.setPlaylistPaths(['/a.flac']);
+        store.clearPlaylist();
+        expect(store.currentClipPath, isNull);
+      });
+    });
+
+    group('setCurrentPlayingIndex', () {
+      test('clamps to 0 when playlist is empty', () {
+        store.setCurrentPlayingIndex(5);
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+
+      test('clamps to last index when value is too large', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac', '/c.flac']);
+        store.setCurrentPlayingIndex(100);
+        expect(store.currentPlayingAudioIndex, equals(2));
+      });
+
+      test('clamps to 0 when value is negative', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac']);
+        store.setCurrentPlayingIndex(-1);
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+
+      test('sets valid index within bounds', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac', '/c.flac']);
+        store.setCurrentPlayingIndex(2);
+        expect(store.currentPlayingAudioIndex, equals(2));
+      });
+    });
+
+    group('nextTrack', () {
+      test('is no-op when playlist is empty', () {
+        store.nextTrack();
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+
+      test('advances index by 1', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac', '/c.flac']);
+        store.nextTrack();
+        expect(store.currentPlayingAudioIndex, equals(1));
+      });
+
+      test('wraps around from last to first', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac']);
+        store.nextTrack(); // 0 → 1
+        store.nextTrack(); // 1 → 0 (wrap)
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+    });
+
+    group('previousTrack', () {
+      test('is no-op when playlist is empty', () {
+        store.previousTrack();
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+
+      test('decrements index by 1', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac', '/c.flac']);
+        store.nextTrack(); // 0 → 1
+        store.previousTrack(); // 1 → 0
+        expect(store.currentPlayingAudioIndex, equals(0));
+      });
+
+      test('wraps from first to last', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac', '/c.flac']);
+        store.previousTrack(); // 0 → 2 (wrap)
+        expect(store.currentPlayingAudioIndex, equals(2));
+      });
+    });
+
+    group('currentClipPath', () {
+      test('returns null when playlist is empty', () {
+        expect(store.currentClipPath, isNull);
+      });
+
+      test('returns path at currentPlayingAudioIndex', () {
+        store.setPlaylistPaths(['/a.flac', '/b.flac']);
+        expect(store.currentClipPath, equals('/a.flac'));
+        store.nextTrack();
+        expect(store.currentClipPath, equals('/b.flac'));
+      });
+    });
+  });
+}

--- a/test/features/session/model/session_store_test.dart
+++ b/test/features/session/model/session_store_test.dart
@@ -163,7 +163,7 @@ void main() {
     // resetResult
     // -------------------------------------------------------------------------
     group('resetResult', () {
-      test('resets all counters to zero', () {
+      test('resets elapsed, correct and incorrect counters to zero', () {
         store.applySubmission(centerFreq: 440.0, isCorrect: true);
         store.applySubmission(centerFreq: 440.0, isCorrect: false);
         store.resetResult();
@@ -171,7 +171,15 @@ void main() {
         expect(store.elapsedSession, equals(0));
         expect(store.resultCorrect, equals(0));
         expect(store.resultIncorrect, equals(0));
-        expect(store.currentSessionPoint, equals(0));
+      });
+
+      test('does NOT reset currentSessionPoint', () {
+        // Two correct answers → sessionPoint = 2
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.applySubmission(centerFreq: 440.0, isCorrect: true);
+        store.resetResult();
+        // sessionPoint is left untouched by resetResult
+        expect(store.currentSessionPoint, equals(2));
       });
 
       test('resets per-band counters to zero', () {

--- a/test/shared/service/playlist_service_test.dart
+++ b/test/shared/service/playlist_service_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+import 'package:eq_trainer/shared/model/audio_clip.dart';
+import 'package:eq_trainer/shared/repository/audio_clip_repository.dart';
+import 'package:eq_trainer/shared/service/app_directories.dart';
+import 'package:eq_trainer/shared/service/playlist_service.dart';
+
+class MockIAudioClipRepository extends Mock implements IAudioClipRepository {}
+
+class MockAppDirectories extends Mock implements AppDirectories {}
+
+void main() {
+  group('PlaylistService', () {
+    late MockIAudioClipRepository mockRepo;
+    late MockAppDirectories mockDirs;
+    late PlaylistService service;
+
+    const String baseClipsPath = '/test/clips';
+
+    setUp(() {
+      mockRepo = MockIAudioClipRepository();
+      mockDirs = MockAppDirectories();
+      service = PlaylistService(mockRepo, mockDirs);
+
+      when(() => mockDirs.getClipsPath()).thenAnswer((_) async => baseClipsPath);
+    });
+
+    // -------------------------------------------------------------------------
+    // listEnabledClipPaths
+    // -------------------------------------------------------------------------
+    group('listEnabledClipPaths', () {
+      test('returns empty list when repository has no clips', () async {
+        when(() => mockRepo.getAllClips()).thenReturn([]);
+        final paths = await service.listEnabledClipPaths();
+        expect(paths, isEmpty);
+      });
+
+      test('returns empty list when all clips are disabled', () async {
+        when(() => mockRepo.getAllClips()).thenReturn([
+          AudioClip('a.flac', 'A', 10.0, false),
+          AudioClip('b.flac', 'B', 20.0, false),
+        ]);
+        final paths = await service.listEnabledClipPaths();
+        expect(paths, isEmpty);
+      });
+
+      test('returns only enabled clips', () async {
+        when(() => mockRepo.getAllClips()).thenReturn([
+          AudioClip('a.flac', 'A', 10.0, true),
+          AudioClip('b.flac', 'B', 20.0, false),
+          AudioClip('c.flac', 'C', 30.0, true),
+        ]);
+        final paths = await service.listEnabledClipPaths();
+        expect(paths.length, equals(2));
+        expect(paths, contains(p.join(baseClipsPath, 'a.flac')));
+        expect(paths, contains(p.join(baseClipsPath, 'c.flac')));
+        expect(paths, isNot(contains(p.join(baseClipsPath, 'b.flac'))));
+      });
+
+      test('joins file names with base clips path correctly', () async {
+        when(() => mockRepo.getAllClips()).thenReturn([
+          AudioClip('track.flac', 'Track', 5.0, true),
+        ]);
+        final paths = await service.listEnabledClipPaths();
+        expect(paths.single, equals(p.join(baseClipsPath, 'track.flac')));
+      });
+
+      test('returns all clips when all are enabled', () async {
+        when(() => mockRepo.getAllClips()).thenReturn([
+          AudioClip('x.flac', 'X', 1.0, true),
+          AudioClip('y.flac', 'Y', 2.0, true),
+        ]);
+        final paths = await service.listEnabledClipPaths();
+        expect(paths.length, equals(2));
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // watchEnabledClipPaths
+    // -------------------------------------------------------------------------
+    group('watchEnabledClipPaths', () {
+      test('emits only enabled clip paths for each repository event', () async {
+        final clips1 = [
+          AudioClip('a.flac', 'A', 10.0, true),
+          AudioClip('b.flac', 'B', 20.0, false),
+        ];
+        final clips2 = [
+          AudioClip('a.flac', 'A', 10.0, true),
+          AudioClip('b.flac', 'B', 20.0, true),
+        ];
+
+        when(() => mockRepo.watchClips())
+            .thenAnswer((_) => Stream.fromIterable([clips1, clips2]));
+
+        final results = await service.watchEnabledClipPaths().toList();
+
+        expect(results.length, equals(2));
+        // First emission: only 'a.flac' is enabled
+        expect(results[0], equals([p.join(baseClipsPath, 'a.flac')]));
+        // Second emission: both enabled
+        expect(results[1], containsAll([
+          p.join(baseClipsPath, 'a.flac'),
+          p.join(baseClipsPath, 'b.flac'),
+        ]));
+      });
+
+      test('emits empty list when all clips are disabled', () async {
+        when(() => mockRepo.watchClips()).thenAnswer((_) => Stream.fromIterable([
+          [AudioClip('a.flac', 'A', 10.0, false)],
+        ]));
+
+        final results = await service.watchEnabledClipPaths().toList();
+        expect(results.single, isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
This PR adds extensive unit test coverage for core session management and playlist functionality, along with enabling the test directory in version control.

## Key Changes
- **SessionStore tests** (329 lines): Comprehensive test suite covering:
  - Result percentage calculations (overall and per-frequency band)
  - Submission handling with correct/incorrect answer tracking
  - Frequency band routing for 7 audio frequency bands (Sub-Bass through Upper-Treble)
  - Session point management (increment, decrement, reset)
  - Playlist management (set paths, clear, navigation, current track tracking)

- **FrequencyCalculator tests** (146 lines): Validation of frequency computation including:
  - Logarithmic and linear frequency list generation
  - Geometric progression verification for log frequencies
  - Even spacing verification for linear frequencies
  - Graph bar data generation for different filter types (peak, dip, peakDip)
  - Spot list generation and value range validation

- **PlaylistService tests** (118 lines): Service layer testing for:
  - Listing enabled audio clips with proper path joining
  - Watching clip changes via reactive streams
  - Filtering disabled clips from results

- **SessionParameter tests** (105 lines): Data model validation including:
  - Default value initialization
  - Boundary clamping for startingBand (2-25 range)
  - Setter functionality for gain, qFactor, filterType, and threshold

- **Project configuration**:
  - Removed `/test/` from `.gitignore` to enable test directory in version control
  - Added `mocktail: ^1.0.0` dependency for mocking in tests

## Notable Implementation Details
- Frequency band boundaries are precisely tested at edge cases (e.g., 79 Hz vs 80 Hz)
- Tests use fresh store instances where needed to ensure isolation
- Mock objects leverage mocktail for clean dependency injection in service tests
- Comprehensive coverage of both happy paths and edge cases (empty playlists, boundary values, wrapping behavior)

https://claude.ai/code/session_01Re7pLgqja6151rFzRP3WtG